### PR TITLE
Cleanup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,18 @@
 FROM debian:stretch
 LABEL maintainer "ant <git@manchestermonkey.co.uk>"
 
-ENV MCVER 1.14.1
-
 RUN apt-get update && apt-get install -y default-jdk wget curl procps
 
 RUN mkdir -p /minecraft/world
 ADD go.sh /minecraft/
+
+
+ENV MCVER 1.14.1
 #ADD https://s3.amazonaws.com/Minecraft.Download/versions/${MCVER}/minecraft_server.${MCVER}.jar /minecraft/
 #RUN ln -s /minecraft/minecraft_server.${MCVER}.jar /minecraft/current.jar
 
 ADD https://launcher.mojang.com/v1/objects/ed76d597a44c5266be2a7fcd77a8270f1f0bc118/server.jar /minecraft/
-RUN ln -s /minecraft/server.jar /minecraft/current.jar
 
 WORKDIR /minecraft/world
 
 CMD ["/minecraft/go.sh"]
-

--- a/go.sh
+++ b/go.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-java -Xmx10240M -Xms10240M -jar /minecraft/current.jar nogui
+java -Xmx10240M -Xms10240M -jar /minecraft/server.jar nogui


### PR DESCRIPTION
- Rejig `Dockerfile` to make better use of build cache
- keeping version variable in the hope someone seems sense and fixes the URL's for the downloads
- removed pointless linking of downloaded jar to `current.jar`, `go.sh` adjusted accordingly.
